### PR TITLE
Optimisations

### DIFF
--- a/PassCodeInputDemo/ContentView.swift
+++ b/PassCodeInputDemo/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct ContentView: View {
     
-    @ObservedObject var passCodeModel = PassCodeInputModel(6)
+    @ObservedObject var passCodeModel = PassCodeInputModel(passCodeLength: 6)
     
     var body: some View {
         Form {

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputCell.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputCell.swift
@@ -27,67 +27,6 @@ class CharacterField: UITextField {
 }
 
 struct PassCodeInputCell : UIViewRepresentable {
-        
-    class Coordinator : NSObject, UITextFieldDelegate, CharacterFieldBackspaceDelegate{
-        
-        // No one else should change this
-        var index: Int
-        // Each cell will update this
-        @Binding var selectedCellIndex: Int
-        // Reference to an index in the text array
-        // from a PassCodeInputModel instance
-        @Binding var textReference: String
-        
-        /**
-         - Parameter index: Index of this cell in the pass code array
-         - Parameter selectedCellIndex: index of where the user is upto
-         - Parameter textReference: reference in the array to update input
-         */
-        init(index: Int, selectedCellIndex: Binding<Int>,
-             textReference: Binding<String>) {
-            // The underscore thing is important due to
-            // the Binding<T> syntax
-            _selectedCellIndex = selectedCellIndex
-            _textReference = textReference
-            self.index = index
-        }
-        
-        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-                        
-            let currentText = textField.text!
-            guard let stringRange = Range(range, in: currentText) else { return false }
-            let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
-            
-            // Increment the index if the change was on char
-            if updatedText.count == 1 {
-                self.selectedCellIndex += 1
-            }
-            
-            // Stop input if there's more than one character
-            return updatedText.count <= 1
-            
-        }
-
-        func textFieldDidChangeSelection(_ textField: UITextField) {
-            DispatchQueue.main.async {
-                self.textReference = textField.text ?? ""
-            }
-        }
-
-        func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-            DispatchQueue.main.async {
-                self.selectedCellIndex = self.index
-            }
-            return true
-        }
-
-        func charFieldWillDeleteBackward(_ textField: CharacterField) {
-            if(textField.text == "" && selectedCellIndex > 0) {
-                self.selectedCellIndex -= 1
-            }
-        }
-
-    }
     
     typealias UIViewType = CharacterField
 
@@ -124,4 +63,64 @@ struct PassCodeInputCell : UIViewRepresentable {
         return Coordinator(index: index, selectedCellIndex: self.$selectedCellIndex, textReference: self.$textReference)
     }
 
+    class Coordinator : NSObject, UITextFieldDelegate, CharacterFieldBackspaceDelegate{
+        
+        // No one else should change this
+        var index: Int
+        // Each cell will update this
+        @Binding var selectedCellIndex: Int
+        // Reference to an index in the text array
+        // from a PassCodeInputModel instance
+        @Binding var textReference: String
+        
+        /**
+         - Parameter index: Index of this cell in the pass code array
+         - Parameter selectedCellIndex: index of where the user is upto
+         - Parameter textReference: reference in the array to update input
+         */
+        init(index: Int, selectedCellIndex: Binding<Int>,
+             textReference: Binding<String>) {
+            // The underscore thing is important due to
+            // the Binding<T> syntax
+            _selectedCellIndex = selectedCellIndex
+            _textReference = textReference
+            self.index = index
+        }
+        
+        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+                        
+            let currentText = textField.text ?? "" //textField.text? will almost assuredly never be nil, but we should always assume it could be
+            guard let stringRange = Range(range, in: currentText) else { return false }
+            let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+            
+            // Increment the index if the change was on char
+            if updatedText.count == 1 {
+                self.selectedCellIndex += 1
+            }
+            
+            // Stop input if there's more than one character
+            return updatedText.count <= 1
+            
+        }
+
+        func textFieldDidChangeSelection(_ textField: UITextField) {
+            DispatchQueue.main.async {
+                self.textReference = textField.text ?? ""
+            }
+        }
+
+        func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+            DispatchQueue.main.async {
+                self.selectedCellIndex = self.index
+            }
+            return true
+        }
+
+        func charFieldWillDeleteBackward(_ textField: CharacterField) {
+            if(textField.text == "" && selectedCellIndex > 0) {
+                self.selectedCellIndex -= 1
+            }
+        }
+
+    }
 }

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputField.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputField.swift
@@ -32,6 +32,6 @@ struct PassCodeInputField: View {
 
 struct PassCodeInputField_Previews: PreviewProvider {
     static var previews: some View {
-        PassCodeInputField(inputModel: PassCodeInputModel(6))
+        PassCodeInputField(inputModel: PassCodeInputModel(passCodeLength: 6))
     }
 }

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
@@ -56,7 +56,7 @@ class PassCodeInputModel : ObservableObject {
     /**
      - Parameters passCodeLength: Number of characters in passcode
      */
-    init(_ passCodeLength: Int) {
+    init(_ passCodeLength: UInt) {
         
         // FIXME: - Is there a better way of doing this?
         for _ in 1...passCodeLength {

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
@@ -44,19 +44,19 @@ class PassCodeInputModel : ObservableObject {
     }
     
     /**
-     - Parameters passCodeLength: Number of characters in passcode
+     - Parameters passCodeLength: Number of characters in passcode. Must be greater than 0.
      */
     init(passCodeLength: UInt) {
         
         // FIXME: - Is there a better way of doing this?
-        for _ in 1...passCodeLength {
+        for _ in 0 ..< passCodeLength {
             self.passCode.append("")
         }
 
         passCodeValidPublisher
-        .receive(on: RunLoop.main)
-        .assign(to: \.isValid, on: self)
-        .store(in: &cancellableSet)
+            .receive(on: RunLoop.main)
+            .assign(to: \.isValid, on: self)
+            .store(in: &cancellableSet)
 
     }
     

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
@@ -21,7 +21,9 @@ class PassCodeInputModel : ObservableObject {
     private var passCodeValidPublisher: AnyPublisher<Bool, Never> {
         $passCode
             .removeDuplicates()
-            .allSatisfy { $0.count != 1 }
+            .map {
+                $0.allSatisfy { $0.count == 1 }
+        }
             .eraseToAnyPublisher()
     }
     

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
@@ -20,19 +20,9 @@ class PassCodeInputModel : ObservableObject {
     private var cancellableSet: Set<AnyCancellable> = []
     private var passCodeValidPublisher: AnyPublisher<Bool, Never> {
         $passCode
-        .removeDuplicates()
-        .map { input in
-            var validity = true
-            // FIXME: - Find a better way of doing this?
-            input.forEach {
-                if $0.count != 1 {
-                    validity = false
-                    return
-                }
-            }
-            return validity
-        }
-        .eraseToAnyPublisher()
+            .removeDuplicates()
+            .allSatisfy { $0.count != 1 }
+            .eraseToAnyPublisher()
     }
     
     /**

--- a/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
+++ b/PassCodeInputDemo/PassCodeInput/PassCodeInputModel.swift
@@ -56,7 +56,7 @@ class PassCodeInputModel : ObservableObject {
     /**
      - Parameters passCodeLength: Number of characters in passcode
      */
-    init(_ passCodeLength: UInt) {
+    init(passCodeLength: UInt) {
         
         // FIXME: - Is there a better way of doing this?
         for _ in 1...passCodeLength {


### PR DESCRIPTION
# Summary of changes

- I switched the passCodeLength `Int` to `UInt`. It just makes sure that the values are zero or above (and the compiler will error out other).
- Exposed the `PassCodeInputField`'s initialiser parameter name for readability
- Optimised the validation testing with a combination of `map` and `allSatisfy`. Using `allSatisfy` directly yielded one pass through only.
- Moved the `PassCodeInputCell.Coordinator` to the bottom of `PassCodeInputCell.Coordinator`, leaving all the variables at the top of the struct.
- Made PassCodeInputModel init iterator start at 0